### PR TITLE
feat: redesign notro-ui CLI to match Starwind-style command structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,38 @@ pnpm --filter notro-tail run preview
 - `pnpm run build` が通らない状態で push しないこと
 - スタイリング変更は必ず `pnpm --filter notro-tail run preview` で目視確認してからコミットすること
 
+### notro-ui コンポーネントの管理
+
+Notion ブロックコンポーネントは `notro-ui` CLI で管理する。`packages/notro-ui/src/templates/` が正（Single Source of Truth）であり、`templates/` はそのコピーを保持する。
+
+#### 基本フロー
+
+```bash
+# 新規テンプレートにコンポーネントを一括追加（既存ファイルはスキップ）
+notro-ui add --all
+
+# notro-ui 側の更新をテンプレートに反映（ローカル変更を上書き）
+notro-ui update --all --yes
+```
+
+#### コマンド一覧
+
+| コマンド | 動作 |
+|---------|------|
+| `notro-ui init` | `notro.json` を生成、`notro-theme.css` を配置 |
+| `notro-ui add [名前...] [--all]` | コンポーネントを追加（**既存ファイルはスキップ**） |
+| `notro-ui update [名前...] [--all] [--yes]` | コンポーネントを更新（**ローカル変更を上書き**） |
+| `notro-ui remove [名前...] [--all]` | コンポーネントを削除 |
+| `notro-ui list [--installed]` | 利用可能 / インストール済みコンポーネントを表示 |
+
+#### 運用ルール
+
+- **カスタマイズ済みファイルの保護**: `add` はデフォルトで既存ファイルをスキップする。テンプレート側でコンポーネントをカスタマイズした場合、`add` を再実行しても上書きされない
+- **意図的な更新**: notro-ui 本体の変更をテンプレートに取り込む場合のみ `update` を使う。`--yes` なしで実行すると確認プロンプトが出る
+- **`notro.json`**: プロジェクトルートに置かれる設定ファイル。`outDir`、`stylesDir`、インストール済みコンポーネント一覧を管理する。git に含める
+
+---
+
 ### サブエージェント・ブランチ管理
 
 - サブエージェント（Agent ツール）で作業させたブランチは、呼び出し元のブランチに **マージしてから** push すること

--- a/packages/notro-ui/bin/notro-ui.js
+++ b/packages/notro-ui/bin/notro-ui.js
@@ -3,168 +3,471 @@
  * notro-ui CLI
  *
  * Usage:
- *   notro-ui init [--out-dir <dir>]   Copy ALL components to src/components/notro/
- *   notro-ui add <component>           Copy a single component file
- *   notro-ui list                      List available components
+ *   notro-ui init                              Initialize project (creates notro.json, copies theme.css)
+ *   notro-ui add [components...] [--all] [-y]  Add components (skips existing files)
+ *   notro-ui update [components...] [--all] [-y]  Update components (overwrites local changes)
+ *   notro-ui remove [components...] [--all]    Remove components
+ *   notro-ui list [--installed]                List available or installed components
  *
  * Examples:
  *   notro-ui init
- *   notro-ui add callout
- *   notro-ui add toggle
+ *   notro-ui add callout toggle
+ *   notro-ui add --all
+ *   notro-ui update callout --yes
+ *   notro-ui update --all --yes
+ *   notro-ui remove callout
+ *   notro-ui list
+ *   notro-ui list --installed
  */
 
 import { fileURLToPath } from 'node:url';
-import { dirname, join, resolve, basename } from 'node:path';
+import { dirname, join, resolve, relative } from 'node:path';
 import {
   copyFileSync,
   mkdirSync,
   existsSync,
-  readdirSync,
+  readFileSync,
   writeFileSync,
+  unlinkSync,
 } from 'node:fs';
+import readline from 'node:readline';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = resolve(__dirname, '..', 'src', 'templates');
 
-// All template files (excluding theme.css which goes to styles/)
-const COMPONENT_FILES = readdirSync(TEMPLATES_DIR).filter(
-  (f) => f !== 'theme.css',
-);
+// ── ANSI color helpers ────────────────────────────────────────────────────────
 
-const COMPONENT_NAMES = COMPONENT_FILES.map((f) =>
-  f.replace(/\.(astro|ts)$/, '').toLowerCase(),
-);
+const c = {
+  reset:  '\x1b[0m',
+  bold:   '\x1b[1m',
+  green:  '\x1b[32m',
+  yellow: '\x1b[33m',
+  red:    '\x1b[31m',
+  gray:   '\x1b[90m',
+  cyan:   '\x1b[36m',
+};
 
-function printHelp() {
-  console.log(`
-notro-ui — Notion block component installer
+const green  = (s) => `${c.green}${s}${c.reset}`;
+const yellow = (s) => `${c.yellow}${s}${c.reset}`;
+const red    = (s) => `${c.red}${s}${c.reset}`;
+const gray   = (s) => `${c.gray}${s}${c.reset}`;
+const bold   = (s) => `${c.bold}${s}${c.reset}`;
+const cyan   = (s) => `${c.cyan}${s}${c.reset}`;
 
-Usage:
-  notro-ui init [--out-dir <dir>]    Copy ALL components (default: src/components/notro/)
-  notro-ui add <component>            Copy a single component
-  notro-ui list                       List available components
+// ── Component registry ────────────────────────────────────────────────────────
 
-Components:
-  ${COMPONENT_NAMES.join(', ')}
-`);
+/** Named component groups: each key is the user-facing component name. */
+const COMPONENT_MAP = {
+  callout:          ['Callout.astro'],
+  toggle:           ['Toggle.astro', 'ToggleTitle.astro'],
+  columns:          ['Columns.astro', 'Column.astro'],
+  audio:            ['Audio.astro'],
+  video:            ['Video.astro'],
+  file:             ['FileBlock.astro'],
+  pdf:              ['PdfBlock.astro'],
+  pageref:          ['PageRef.astro'],
+  databaseref:      ['DatabaseRef.astro'],
+  tableofcontents:  ['TableOfContents.astro'],
+  emptyblock:       ['EmptyBlock.astro'],
+  mention:          ['Mention.astro', 'MentionDate.astro'],
+  h1:               ['H1.astro'],
+  h2:               ['H2.astro'],
+  h3:               ['H3.astro'],
+  h4:               ['H4.astro'],
+  quote:            ['Quote.astro'],
+  styledspan:       ['StyledSpan.astro'],
+  image:            ['ImageBlock.astro'],
+  table:            ['TableBlock.astro', 'TableColgroup.astro', 'TableCol.astro', 'TableRow.astro', 'TableCell.astro'],
+  coloredparagraph: ['ColoredParagraph.astro'],
+  syncedblock:      ['SyncedBlock.astro'],
+};
+
+/** Core files always present — installed alongside components (not user-selectable). */
+const CORE_FILES = ['colors.ts', 'index.ts'];
+
+const COMPONENT_NAMES = Object.keys(COMPONENT_MAP);
+
+// ── Config (notro.json) ───────────────────────────────────────────────────────
+
+const CONFIG_FILE = 'notro.json';
+const DEFAULT_OUT_DIR    = 'src/components/notro';
+const DEFAULT_STYLES_DIR = 'src/styles';
+
+function configPath(cwd) {
+  return join(cwd, CONFIG_FILE);
 }
+
+function readConfig(cwd) {
+  const p = configPath(cwd);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, 'utf8'));
+  } catch {
+    console.error(red(`Error: failed to parse ${CONFIG_FILE}`));
+    process.exit(1);
+  }
+}
+
+function writeConfig(cwd, config) {
+  writeFileSync(configPath(cwd), JSON.stringify(config, null, 2) + '\n');
+}
+
+function requireConfig(cwd) {
+  const cfg = readConfig(cwd);
+  if (!cfg) {
+    console.error(red(`Error: ${CONFIG_FILE} not found.`));
+    console.error(gray(`  Run ${bold('notro-ui init')} first.`));
+    process.exit(1);
+  }
+  return cfg;
+}
+
+// ── File system helpers ───────────────────────────────────────────────────────
 
 function ensureDir(dir) {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
-    console.log(`  Created ${dir}`);
   }
 }
 
-function copyTemplate(filename, destDir) {
-  const src = join(TEMPLATES_DIR, filename);
+/**
+ * Copy a single template file to destDir.
+ * @param {string} filename
+ * @param {string} destDir
+ * @param {'skip'|'overwrite'} strategy - 'skip' leaves existing files untouched
+ * @returns {'added'|'updated'|'skipped'}
+ */
+function copyTemplate(filename, destDir, strategy) {
+  const src  = join(TEMPLATES_DIR, filename);
   const dest = join(destDir, filename);
-  const existed = existsSync(dest);
+  if (existsSync(dest)) {
+    if (strategy === 'skip') return 'skipped';
+    copyFileSync(src, dest);
+    return 'updated';
+  }
   copyFileSync(src, dest);
-  console.log(`  ${existed ? 'Updated' : 'Added  '} ${dest}`);
+  return 'added';
 }
 
-function initCommand(args) {
-  const outDirFlag = args.indexOf('--out-dir');
-  const outDir = outDirFlag >= 0
-    ? resolve(process.cwd(), args[outDirFlag + 1])
-    : resolve(process.cwd(), 'src', 'components', 'notro');
+function displayPath(absPath, cwd) {
+  return relative(cwd, absPath);
+}
 
-  const stylesDir = resolve(process.cwd(), 'src', 'styles');
+// ── Confirmation prompt ───────────────────────────────────────────────────────
 
-  console.log('\nnotro-ui init\n');
+function confirm(message) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`${message} ${gray('(y/N)')} `, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y');
+    });
+  });
+}
 
-  ensureDir(outDir);
-  ensureDir(stylesDir);
+// ── Resolve component names → file lists ─────────────────────────────────────
 
-  // Copy all component files
-  for (const file of COMPONENT_FILES) {
-    copyTemplate(file, outDir);
+function resolveFiles(names) {
+  const unknown = names.filter((n) => !COMPONENT_MAP[n]);
+  if (unknown.length > 0) {
+    console.error(red(`Error: unknown component(s): ${unknown.join(', ')}`));
+    console.error(gray(`  Run ${bold('notro-ui list')} to see available components.`));
+    process.exit(1);
+  }
+  return names.flatMap((n) => COMPONENT_MAP[n]);
+}
+
+// ── Commands ──────────────────────────────────────────────────────────────────
+
+function initCommand() {
+  const cwd = process.cwd();
+
+  console.log(`\n${bold('notro-ui init')}\n`);
+
+  // Write notro.json if it doesn't exist
+  const cfgFile = configPath(cwd);
+  if (existsSync(cfgFile)) {
+    console.log(yellow(`  ${CONFIG_FILE} already exists — skipping config creation.`));
+  } else {
+    const config = {
+      outDir:     DEFAULT_OUT_DIR,
+      stylesDir:  DEFAULT_STYLES_DIR,
+      components: [],
+    };
+    writeConfig(cwd, config);
+    console.log(green(`  Created  ${CONFIG_FILE}`));
   }
 
-  // Copy theme.css to src/styles/
-  const themeSrc = join(TEMPLATES_DIR, 'theme.css');
+  // Copy theme.css → src/styles/notro-theme.css (skip if already present)
+  const cfg       = readConfig(cwd);
+  const stylesDir = resolve(cwd, cfg?.stylesDir ?? DEFAULT_STYLES_DIR);
+  ensureDir(stylesDir);
+  const themeSrc  = join(TEMPLATES_DIR, 'theme.css');
   const themeDest = join(stylesDir, 'notro-theme.css');
-  const themeExisted = existsSync(themeDest);
-  copyFileSync(themeSrc, themeDest);
-  console.log(`  ${themeExisted ? 'Updated' : 'Added  '} ${themeDest}`);
+  if (existsSync(themeDest)) {
+    console.log(gray(`  Skipped  ${displayPath(themeDest, cwd)}  (already exists)`));
+  } else {
+    copyFileSync(themeSrc, themeDest);
+    console.log(green(`  Added    ${displayPath(themeDest, cwd)}`));
+  }
 
   console.log(`
-Done! ${COMPONENT_FILES.length} files installed.
+${bold('Next steps:')}
+  1. Add to your CSS (e.g. ${cyan('src/styles/global.css')}):
+       ${gray('@import "./notro-theme.css";')}
 
-Next steps:
-  1. Add to your main CSS file (e.g. src/styles/global.css):
-       @import "./notro-theme.css";
+  2. Add components:
+       ${cyan('notro-ui add --all')}
 
-  2. Import in your page:
-       import { NotroContent } from 'notro';
-       import { notroComponents } from '../components/notro';
-
-  3. Use it:
-       <NotroContent markdown={markdown} {linkToPages} components={notroComponents} />
-
-  To override a component:
-       components={{ ...notroComponents, callout: MyCallout }}
+  3. Import in your page:
+       ${gray('import { NotroContent } from "notro-loader";')}
+       ${gray('import { notroComponents } from "@/components/notro";')}
+       ${gray('<NotroContent markdown={markdown} {linkToPages} components={notroComponents} />')}
 `);
 }
 
-function addCommand(name) {
-  if (!name) {
-    console.error('Error: specify a component name.\n  notro-ui add callout');
+async function addCommand(names, flags) {
+  const cwd = process.cwd();
+  const cfg = requireConfig(cwd);
+
+  const outDir = resolve(cwd, cfg.outDir ?? DEFAULT_OUT_DIR);
+  ensureDir(outDir);
+
+  const useAll = flags.all;
+  const targets = useAll ? COMPONENT_NAMES : names;
+
+  if (targets.length === 0) {
+    console.error(red('Error: specify component name(s) or use --all.'));
+    console.error(gray(`  Example: ${bold('notro-ui add callout toggle')}`));
+    console.error(gray(`           ${bold('notro-ui add --all')}`));
     process.exit(1);
   }
 
-  const outDir = resolve(process.cwd(), 'src', 'components', 'notro');
+  const files = resolveFiles(targets);
 
-  if (!existsSync(outDir)) {
-    console.error(
-      `Error: ${outDir} not found.\nRun "notro-ui init" first to set up the components directory.`,
-    );
-    process.exit(1);
+  console.log(`\n${bold('notro-ui add')}\n`);
+
+  // Install core files (skip if present)
+  for (const f of CORE_FILES) {
+    const result = copyTemplate(f, outDir, 'skip');
+    const dest   = displayPath(join(outDir, f), cwd);
+    if (result === 'skipped') {
+      console.log(gray(`  Skipped  ${dest}  (already exists)`));
+    } else {
+      console.log(green(`  Added    ${dest}`));
+    }
   }
 
-  // Find matching file(s) — name is case-insensitive
-  const matches = COMPONENT_FILES.filter(
-    (f) => f.toLowerCase().startsWith(name.toLowerCase()),
-  );
-
-  if (matches.length === 0) {
-    console.error(
-      `Error: no component matching "${name}".\nRun "notro-ui list" to see available components.`,
-    );
-    process.exit(1);
+  // Install component files (skip if present)
+  let addedCount   = 0;
+  let skippedCount = 0;
+  for (const f of files) {
+    const result = copyTemplate(f, outDir, 'skip');
+    const dest   = displayPath(join(outDir, f), cwd);
+    if (result === 'skipped') {
+      console.log(gray(`  Skipped  ${dest}  (already exists)`));
+      skippedCount++;
+    } else {
+      console.log(green(`  Added    ${dest}`));
+      addedCount++;
+    }
   }
 
-  console.log('\nnotro-ui add\n');
+  // Update notro.json components list (add new entries)
+  const existing = new Set(cfg.components ?? []);
+  for (const name of targets) existing.add(name);
+  cfg.components = [...existing].sort();
+  writeConfig(cwd, cfg);
+  console.log(green(`  Updated  ${CONFIG_FILE}`));
 
-  for (const file of matches) {
-    copyTemplate(file, outDir);
-  }
-
-  console.log('\nDone!');
+  console.log(`\n${green('Done!')}  ${addedCount} added, ${skippedCount} skipped.\n`);
 }
 
-function listCommand() {
-  console.log('\nAvailable components:\n');
-  for (const name of COMPONENT_NAMES) {
-    console.log(`  ${name}`);
+async function updateCommand(names, flags) {
+  const cwd = process.cwd();
+  const cfg = requireConfig(cwd);
+
+  const outDir = resolve(cwd, cfg.outDir ?? DEFAULT_OUT_DIR);
+  const useAll = flags.all;
+  const useYes = flags.yes;
+
+  let targets;
+  if (useAll) {
+    targets = cfg.components ?? [];
+    if (targets.length === 0) {
+      console.error(yellow('No components installed yet. Run notro-ui add --all first.'));
+      process.exit(0);
+    }
+  } else {
+    targets = names;
+    if (targets.length === 0) {
+      console.error(red('Error: specify component name(s) or use --all.'));
+      console.error(gray(`  Example: ${bold('notro-ui update callout')}`));
+      console.error(gray(`           ${bold('notro-ui update --all --yes')}`));
+      process.exit(1);
+    }
   }
-  console.log();
+
+  const files = resolveFiles(targets);
+
+  console.log(`\n${bold('notro-ui update')}\n`);
+  console.log(yellow('  Warning: this will overwrite your local changes to these components.'));
+  console.log(gray(`  Components: ${targets.join(', ')}\n`));
+
+  if (!useYes) {
+    const ok = await confirm('  Continue?');
+    if (!ok) {
+      console.log(gray('\n  Aborted.\n'));
+      process.exit(0);
+    }
+    console.log();
+  }
+
+  // Update core files
+  for (const f of CORE_FILES) {
+    const result = copyTemplate(f, outDir, 'overwrite');
+    const dest   = displayPath(join(outDir, f), cwd);
+    console.log(green(`  Updated  ${dest}`));
+  }
+
+  // Update component files
+  let updatedCount = 0;
+  for (const f of files) {
+    const result = copyTemplate(f, outDir, 'overwrite');
+    const dest   = displayPath(join(outDir, f), cwd);
+    console.log(green(`  Updated  ${dest}`));
+    updatedCount++;
+  }
+
+  console.log(`\n${green('Done!')}  ${updatedCount} file(s) updated.\n`);
 }
 
-// ── Main ─────────────────────────────────────────────────────────────────────
+function removeCommand(names, flags) {
+  const cwd = process.cwd();
+  const cfg = requireConfig(cwd);
 
-const [, , command, ...args] = process.argv;
+  const outDir = resolve(cwd, cfg.outDir ?? DEFAULT_OUT_DIR);
+  const useAll = flags.all;
+
+  const targets = useAll ? (cfg.components ?? []) : names;
+
+  if (targets.length === 0) {
+    console.error(red('Error: specify component name(s) or use --all.'));
+    process.exit(1);
+  }
+
+  // Validate names first
+  resolveFiles(targets);
+
+  console.log(`\n${bold('notro-ui remove')}\n`);
+
+  let removedCount = 0;
+  for (const name of targets) {
+    for (const f of COMPONENT_MAP[name]) {
+      const dest = join(outDir, f);
+      if (existsSync(dest)) {
+        unlinkSync(dest);
+        console.log(green(`  Removed  ${displayPath(dest, cwd)}`));
+        removedCount++;
+      } else {
+        console.log(gray(`  Missing  ${displayPath(dest, cwd)}  (already removed)`));
+      }
+    }
+  }
+
+  // Update notro.json
+  cfg.components = (cfg.components ?? []).filter((n) => !targets.includes(n));
+  writeConfig(cwd, cfg);
+  console.log(green(`  Updated  ${CONFIG_FILE}`));
+
+  console.log(`\n${green('Done!')}  ${removedCount} file(s) removed.\n`);
+}
+
+function listCommand(flags) {
+  const cwd = process.cwd();
+
+  if (flags.installed) {
+    const cfg = readConfig(cwd);
+    const installed = cfg?.components ?? [];
+    if (installed.length === 0) {
+      console.log(gray('\n  No components installed. Run notro-ui add --all to get started.\n'));
+      return;
+    }
+    console.log(`\n${bold('Installed components:')}\n`);
+    for (const name of installed) {
+      const files = COMPONENT_MAP[name] ?? [];
+      console.log(`  ${green(name.padEnd(20))} ${gray(files.join(', '))}`);
+    }
+    console.log();
+  } else {
+    console.log(`\n${bold('Available components:')}\n`);
+    for (const [name, files] of Object.entries(COMPONENT_MAP)) {
+      console.log(`  ${cyan(name.padEnd(20))} ${gray(files.join(', '))}`);
+    }
+    console.log();
+  }
+}
+
+function printHelp() {
+  console.log(`
+${bold('notro-ui')} — Notion block component installer
+
+${bold('Usage:')}
+  notro-ui ${cyan('init')}                               Initialize project (creates notro.json)
+  notro-ui ${cyan('add')} [components...] [--all] [-y]   Add components ${gray('(skips existing)')}
+  notro-ui ${cyan('update')} [components...] [--all] [-y] Update components ${yellow('(overwrites local changes)')}
+  notro-ui ${cyan('remove')} [components...] [--all]     Remove components
+  notro-ui ${cyan('list')} [--installed]                 List available or installed components
+
+${bold('Options:')}
+  -a, --all     Target all components
+  -y, --yes     Skip confirmation prompts
+
+${bold('Examples:')}
+  notro-ui init
+  notro-ui add callout toggle
+  notro-ui add --all
+  notro-ui update --all --yes
+  notro-ui remove callout
+  notro-ui list
+  notro-ui list --installed
+`);
+}
+
+// ── Argument parser ───────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const flags = { all: false, yes: false, installed: false };
+  const names = [];
+  for (const arg of argv) {
+    if (arg === '--all' || arg === '-a')       flags.all       = true;
+    else if (arg === '--yes' || arg === '-y')  flags.yes       = true;
+    else if (arg === '--installed')            flags.installed = true;
+    else if (!arg.startsWith('-'))             names.push(arg.toLowerCase());
+  }
+  return { flags, names };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+const [, , command, ...rawArgs] = process.argv;
+const { flags, names } = parseArgs(rawArgs);
 
 switch (command) {
   case 'init':
-    initCommand(args);
+    initCommand();
     break;
   case 'add':
-    addCommand(args[0]);
+    await addCommand(names, flags);
+    break;
+  case 'update':
+    await updateCommand(names, flags);
+    break;
+  case 'remove':
+    removeCommand(names, flags);
     break;
   case 'list':
-    listCommand();
+    listCommand(flags);
     break;
   default:
     printHelp();


### PR DESCRIPTION
- Replace monolithic copy-all approach with named commands:
  init / add / update / remove / list
- add: skips existing files by default (no accidental overwrites)
- update: overwrites with warning + --yes confirmation bypass
- --all flag targets all components; --installed flag for list
- Introduce notro.json config to track installed component list
- Group related files under logical component names (e.g. toggle →
  Toggle.astro + ToggleTitle.astro; table → 5 files)
- ANSI color output (green=added, yellow=warn, gray=skipped)
- Update CLAUDE.md: document add --all / update --all --yes workflow

https://claude.ai/code/session_01QeSgLSZ8wQeEAu8tCVoZDg