### PR TITLE
Build packages with tsdown and improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -15,22 +16,19 @@ jobs:
       id-token: write
       pull-requests: write
 
-    strategy:
-      matrix:
-        node-version: [22.x]
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
 
@@ -43,3 +41,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "docs:build": "pnpm --filter notro-docs run build",
     "test": "pnpm -r run test",
     "format": "pnpm -r run format",
+    "build:packages": "pnpm --filter remark-nfm --filter rehype-beautiful-mermaid --filter create-notro run build",
     "changeset-version": "changeset version",
-    "changeset-publish": "pnpm run build && changeset publish"
+    "changeset-publish": "pnpm run build:packages && changeset publish"
   },
   "engines": {
     "node": ">=22.0.0",

--- a/packages/notro-loader/package.json
+++ b/packages/notro-loader/package.json
@@ -58,6 +58,7 @@
     "vitest": "^4.1.0"
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   },
   "dependencies": {

--- a/packages/notro-ui/package.json
+++ b/packages/notro-ui/package.json
@@ -17,5 +17,9 @@
   },
   "peerDependencies": {
     "tailwind-variants": ">=0.3.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/rehype-beautiful-mermaid/package.json
+++ b/packages/rehype-beautiful-mermaid/package.json
@@ -24,14 +24,22 @@
     ".": "./index.ts"
   },
   "files": [
-    "index.ts",
-    "src"
+    "dist"
   ],
   "scripts": {
+    "prepack": "tsdown",
+    "build": "tsdown",
     "format": "prettier --write 'src/**/*.ts'"
   },
   "publishConfig": {
-    "provenance": true
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
   },
   "dependencies": {
     "hast-util-from-html-isomorphic": "^2.0.0",
@@ -48,6 +56,7 @@
     "node": ">=22.0.0"
   },
   "devDependencies": {
+    "tsdown": "^0.12.9",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/rehype-beautiful-mermaid/tsconfig.json
+++ b/packages/rehype-beautiful-mermaid/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts", "src"]
+}

--- a/packages/rehype-beautiful-mermaid/tsdown.config.mjs
+++ b/packages/rehype-beautiful-mermaid/tsdown.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  entry: ['index.ts'],
+  format: 'esm',
+  dts: true,
+  outDir: 'dist',
+  hash: false,
+};

--- a/packages/remark-nfm/package.json
+++ b/packages/remark-nfm/package.json
@@ -25,15 +25,23 @@
     ".": "./index.ts"
   },
   "files": [
-    "index.ts",
-    "src"
+    "dist"
   ],
   "scripts": {
+    "prepack": "tsdown",
+    "build": "tsdown",
     "format": "prettier --write 'src/**/*.ts'",
     "test": "vitest run"
   },
   "publishConfig": {
-    "provenance": true
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
   },
   "dependencies": {
     "mdast-util-directive": "^3.0.0",
@@ -51,6 +59,7 @@
     "unified": ">=11.0.0"
   },
   "devDependencies": {
+    "tsdown": "^0.12.9",
     "typescript": "^5.9.3",
     "vitest": "^4.1.0"
   }

--- a/packages/remark-nfm/tsconfig.json
+++ b/packages/remark-nfm/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts", "src"]
+}

--- a/packages/remark-nfm/tsdown.config.mjs
+++ b/packages/remark-nfm/tsdown.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  entry: ['index.ts'],
+  format: 'esm',
+  dts: true,
+  outDir: 'dist',
+  hash: false,
+};


### PR DESCRIPTION
## Summary
This PR modernizes the package build process by introducing tsdown as the build tool and improves the CI/CD release workflow with better Node.js setup and manual trigger support.

## Key Changes

### Build System
- Added `tsdown` as the build tool for `remark-nfm` and `rehype-beautiful-mermaid` packages
- Created `tsconfig.json` and `tsdown.config.mjs` for both packages to configure TypeScript compilation to ESM with declaration files
- Updated package.json `files` field to publish only the `dist` directory instead of source files
- Added `build` and `prepack` scripts to both packages for automated compilation
- Updated `publishConfig` to include proper `exports` field pointing to compiled output

### Release Workflow
- Added `workflow_dispatch` trigger to allow manual release workflow execution
- Removed matrix strategy for Node.js version (was only 22.x anyway)
- Reordered steps: pnpm setup now comes before Node.js setup
- Added `registry-url` to Node.js setup action for proper npm registry configuration
- Added `NODE_AUTH_TOKEN` environment variable for npm authentication
- Updated root `changeset-publish` script to use new `build:packages` command

### Package Configuration
- Added `access: "public"` to `publishConfig` in all packages for explicit public access
- Added `access: "public"` and `provenance: true` to `notro-ui` and `notro-loader` packages
- Ensured consistent publish configuration across all packages

## Implementation Details
- Both `remark-nfm` and `rehype-beautiful-mermaid` now use identical tsdown and TypeScript configurations
- The build process generates ESM modules with TypeScript declaration files in the `dist` directory
- The release workflow now supports both automatic (on push to main) and manual (workflow_dispatch) triggers
- All packages are configured for public npm registry publication with provenance tracking

https://claude.ai/code/session_01BQ9osJyyzTuTJopErqw96h