### PR TITLE
Update release workflow and changelog configuration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", { "repo": "mosugi/notro" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install latest npm
+        run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
@@ -40,5 +43,3 @@ jobs:
           publish: pnpm run changeset-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
This PR updates the CI/CD release workflow and changelog generation configuration to improve the release process.

## Key Changes
- **Release Workflow**: Added a step to install the latest npm version before running pnpm install, ensuring the most up-to-date npm tooling is available during releases
- **NPM Authentication**: Removed explicit NPM_TOKEN and NODE_AUTH_TOKEN environment variables from the release workflow, as npm authentication is now handled through the configured registry-url
- **Changelog Generation**: Updated the changelog configuration to use `@changesets/changelog-github` instead of the default `@changesets/cli/changelog`, enabling GitHub-integrated changelog generation with repository context (`mosugi/notro`)

## Implementation Details
The removal of explicit token environment variables suggests a shift to relying on npm's built-in authentication mechanism via the registry-url configuration, which is a cleaner approach for GitHub Actions workflows.

https://claude.ai/code/session_01Fw1tZ7P75ecD8QFNB71z38