### PR TITLE
fix: remove duplicate pnpm version from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4


### PR DESCRIPTION
pnpm/action-setup@v4 automatically reads the version from
package.json's packageManager field (pnpm@10.33.0), so specifying
version: 10 in the action config causes ERR_PNPM_BAD_PM_VERSION.