### PR TITLE
fix: correct repository URLs from NotroTail to notro in package.json

### DIFF
--- a/packages/rehype-beautiful-mermaid/package.json
+++ b/packages/rehype-beautiful-mermaid/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mosugi/NotroTail.git",
+    "url": "git+https://github.com/mosugi/notro.git",
     "directory": "packages/rehype-beautiful-mermaid"
   },
   "keywords": [
@@ -17,7 +17,7 @@
     "unified"
   ],
   "bugs": {
-    "url": "https://github.com/mosugi/NotroTail/issues"
+    "url": "https://github.com/mosugi/notro/issues"
   },
   "homepage": "https://notrotail.mosugi.com",
   "exports": {

--- a/packages/remark-nfm/package.json
+++ b/packages/remark-nfm/package.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mosugi/NotroTail.git",
-    "directory": "packages/remark-notro"
+    "url": "git+https://github.com/mosugi/notro.git",
+    "directory": "packages/remark-nfm"
   },
   "keywords": [
     "remark",
@@ -18,7 +18,7 @@
     "unified"
   ],
   "bugs": {
-    "url": "https://github.com/mosugi/NotroTail/issues"
+    "url": "https://github.com/mosugi/notro/issues"
   },
   "homepage": "https://notrotail.mosugi.com",
   "exports": {


### PR DESCRIPTION
Update repository.url and bugs.url in rehype-beautiful-mermaid and
remark-nfm to use the correct repository name (mosugi/notro) for
OIDC trusted publishing. Also fix remark-nfm's repository.directory
from packages/remark-notro to packages/remark-nfm.

https://claude.ai/code/session_01GzNNRfY3Mo1yVWrMkmTQYE