### PR TITLE
fix: add vercel.json to templates/blog and docs for correct output directory

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,6 +1,3 @@
 {
-  "framework": null,
-  "installCommand": "pnpm install",
-  "buildCommand": "pnpm run build",
   "outputDirectory": "dist"
 }

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": null,
+  "installCommand": "corepack enable && corepack prepare pnpm@10.33.0 --activate && pnpm install",
+  "buildCommand": "pnpm run build",
+  "outputDirectory": "dist"
+}

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": null,
-  "installCommand": "corepack enable && corepack prepare pnpm@10.33.0 --activate && pnpm install",
+  "installCommand": "pnpm install",
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist"
 }

--- a/templates/blog/vercel.json
+++ b/templates/blog/vercel.json
@@ -1,6 +1,3 @@
 {
-  "framework": null,
-  "installCommand": "pnpm install",
-  "buildCommand": "pnpm run build",
   "outputDirectory": "dist"
 }

--- a/templates/blog/vercel.json
+++ b/templates/blog/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": null,
+  "installCommand": "corepack enable && corepack prepare pnpm@10.33.0 --activate && pnpm install",
+  "buildCommand": "pnpm run build",
+  "outputDirectory": "dist"
+}

--- a/templates/blog/vercel.json
+++ b/templates/blog/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": null,
-  "installCommand": "corepack enable && corepack prepare pnpm@10.33.0 --activate && pnpm install",
+  "installCommand": "pnpm install",
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
+  "framework": null,
   "buildCommand": "pnpm run build",
-  "outputDirectory": "templates/blog/dist",
-  "installCommand": "pnpm install",
-  "framework": null
+  "outputDirectory": "templates/blog/dist"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "pnpm run build",
   "outputDirectory": "templates/blog/dist",
-  "installCommand": "corepack enable && corepack prepare pnpm@10.33.0 --activate && pnpm install",
+  "installCommand": "pnpm install",
   "framework": null
 }


### PR DESCRIPTION
When Vercel projects are created with root-directory=templates/blog or
root-directory=docs, only the vercel.json within that directory is read
(not the repo root vercel.json). Without these files, Vercel auto-detects
Astro and looks for dist/ relative to the project root but cannot find it,
causing "No Output Directory named 'dist' found" errors.

- templates/blog/vercel.json: sets outputDirectory=dist for blog deployments
  with root-directory=templates/blog (e.g. created via Deploy to Vercel button)
- docs/vercel.json: sets outputDirectory=dist for docs site deployments
  with root-directory=docs

The root vercel.json (outputDirectory=templates/blog/dist) is unchanged and
continues to serve the notro-tail project which uses the repo root as its
project root.

https://claude.ai/code/session_01JhC9jEcm5HaUJjSRbSqset