### PR TITLE
fix: pass full property object to getPlainText in blank template

### DIFF
--- a/templates/blank/src/pages/[slug].astro
+++ b/templates/blank/src/pages/[slug].astro
@@ -13,7 +13,7 @@ export async function getStaticPaths() {
 }
 
 const { page } = Astro.props;
-const title = getPlainText(page.data.properties.Name.title);
+const title = getPlainText(page.data.properties.Name) ?? "";
 ---
 
 <Layout title={title}>

--- a/templates/blank/src/pages/index.astro
+++ b/templates/blank/src/pages/index.astro
@@ -17,7 +17,7 @@ const sorted = pages.slice().sort((a, b) => {
     <ul class="nt-page-list">
       {sorted.map((page) => {
         const slug = page.data.properties.Slug.rich_text[0]?.plain_text;
-        const title = getPlainText(page.data.properties.Name.title);
+        const title = getPlainText(page.data.properties.Name) ?? "";
         return (
           <li>
             <a href={`/${slug}/`} class="nt-link">{title}</a>


### PR DESCRIPTION
getPlainText expects a PropertyPageObjectResponseType (the whole property
object), not the inner .title array. Also add a ?? "" fallback to satisfy
Layout's required string title prop.