### PR TITLE
Rename notro package to notro-loader throughout monorepo

### DIFF
--- a/.changeset/fix-readme-package-names.md
+++ b/.changeset/fix-readme-package-names.md
@@ -1,0 +1,15 @@
+---
+"remark-notro": patch
+"notro-loader": patch
+"notro-ui": patch
+"rehype-beautiful-mermaid": patch
+---
+
+Fix package name inconsistencies and broken links in README files
+
+- Fix language selector links in root README.md and README.ja.md
+- Fix broken reference to non-existent `packages/notro/README.md`
+- Correct `notro` references to `notro-loader` in notro-ui README
+- Correct `remark-nfm` npm package name to `remark-notro` in notro-loader README
+- Fix import path `notro/integration` → `notro-loader/integration` in rehype-beautiful-mermaid README
+- Update relationship diagram in remark-nfm README to reference `notro-loader`

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,5 @@
 <p>
-<a href="README.ja.md">English</a>
+<a href="README.md">English</a>
  | 
 <a href="./README.ja.md">日本語</a>
 <!-- |
@@ -189,7 +189,7 @@ Notion API はページコンテンツを約 **20,000 ブロック**で切り詰
 
 一部の Notion ブロック型は Notion API によって Markdown に変換されず、レスポンスから無言で除外されます。notro は除外されたブロックの ID を警告ログに出力するので、該当コンテンツを確認・修正できます。
 
-詳細は [Notion API ドキュメント](https://developers.notion.com/reference/retrieve-page-markdown) および `notro` パッケージの [README](./packages/notro/README.md#notion-api-の制限事項) を参照してください。
+詳細は [Notion API ドキュメント](https://developers.notion.com/reference/retrieve-page-markdown) および [`notro-loader` README](./packages/notro-loader/README.md#notion-api-limitations) を参照してください。
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p>
-<a href="README.ja.md">English</a>
+<a href="README.md">English</a>
  | 
 <a href="./README.ja.md">日本語</a>
 <!-- |
@@ -195,7 +195,7 @@ The Notion API truncates page content at approximately **20,000 blocks**. There 
 
 Some Notion block types cannot be converted to Markdown by the API. These blocks are silently omitted from the response. notro logs the affected block IDs so you can identify and update the content.
 
-For details, see the [Notion API documentation](https://developers.notion.com/reference/retrieve-page-markdown) and the `notro` package [README](./packages/notro/README.md#notion-api-の制限事項).
+For details, see the [Notion API documentation](https://developers.notion.com/reference/retrieve-page-markdown) and the [`notro-loader` README](./packages/notro-loader/README.md#notion-api-limitations).
 
 ## Contributing
 

--- a/packages/notro-loader/README.md
+++ b/packages/notro-loader/README.md
@@ -6,7 +6,7 @@
 An Astro Content Loader library that fetches Notion database content via the [Markdown Content API](https://developers.notion.com/) into [Astro Content Collections](https://docs.astro.build/en/guides/content-collections/).
 
 > [!TIP]
-> Sample project: [notro](https://github.com/mosugi/notro)
+> This package is part of the [mosugi/notro](https://github.com/mosugi/notro) monorepo. See the blog template at `templates/blog/` for a full working example.
 
 ## What NotroContent renders
 
@@ -146,17 +146,17 @@ const { entry } = Astro.props;
 
 Components are copied into `src/components/notro/` so you can edit them directly.
 
-## Markdown processing (remark-nfm)
+## Markdown processing (remark-notro)
 
-`notro-loader` delegates Notion Markdown preprocessing and directive syntax support to the [`remark-nfm`](https://www.npmjs.com/package/remark-nfm) package.
+`notro-loader` delegates Notion Markdown preprocessing and directive syntax support to the [`remark-notro`](https://www.npmjs.com/package/remark-notro) package.
 
-`remark-nfm` is used inside notro-loader's MDX compile pipeline and is applied automatically when using `NotroContent`.
+`remark-notro` is used inside notro-loader's MDX compile pipeline and is applied automatically when using `NotroContent`.
 
-If you want to use `remark-nfm` directly (in a custom unified pipeline or `@mdx-js/mdx`'s `evaluate()`), import it from the `remark-nfm` package directly rather than from `notro-loader`.
+If you want to use `remark-notro` directly (in a custom unified pipeline or `@mdx-js/mdx`'s `evaluate()`), import it from the `remark-notro` package directly rather than from `notro-loader`.
 
 ```ts
-// ✅ Import directly from remark-nfm
-import { remarkNfm, preprocessNotionMarkdown } from "remark-nfm";
+// ✅ Import directly from remark-notro
+import { remarkNfm, preprocessNotionMarkdown } from "remark-notro";
 
 // ❌ Not needed from notro-loader (internal use only)
 // import { remarkNfm } from "notro-loader";

--- a/packages/notro-ui/README.md
+++ b/packages/notro-ui/README.md
@@ -47,7 +47,7 @@ npx notro-ui init --out-dir src/components/blocks
 Your project needs:
 
 ```sh
-npm install notro tailwind-variants
+npm install notro-loader tailwind-variants
 ```
 
 And `notro-theme.css` imported in your global CSS (`src/styles/global.css`):
@@ -67,7 +67,7 @@ After `init`, wire up the local `NotroContent` in your page:
 ```astro
 ---
 // src/pages/blog/[slug].astro
-import { buildLinkToPages, getPlainText } from "notro";
+import { buildLinkToPages, getPlainText } from "notro-loader";
 import NotroContent from "../../components/notro/NotroContent.astro";
 
 const { entry } = Astro.props;
@@ -150,14 +150,14 @@ npx notro-ui list
 
 ---
 
-## How it relates to `notro`
+## How it relates to `notro-loader`
 
 | Package | Role |
 |---|---|
-| [`notro`](../notro/) | Headless — Content Loader, MDX pipeline, unstyled components |
-| `notro-ui` | Style layer — copy-and-own styled components that sit on top of `notro` |
+| [`notro-loader`](../notro-loader/) | Headless — Content Loader, MDX pipeline, unstyled components |
+| `notro-ui` | Style layer — copy-and-own styled components that sit on top of `notro-loader` |
 
-`notro` provides `compileMdxCached` (the MDX compiler) and the headless component set. `notro-ui`'s `NotroContent.astro` uses `compileMdxCached` directly and wires in your local styled components.
+`notro-loader` provides `compileMdxCached` (the MDX compiler) and the headless component set. `notro-ui`'s `NotroContent.astro` uses `compileMdxCached` directly and wires in your local styled components.
 
 ---
 

--- a/packages/rehype-beautiful-mermaid/README.md
+++ b/packages/rehype-beautiful-mermaid/README.md
@@ -23,7 +23,7 @@ Pass `rehypeMermaid` to `notro()` in `astro.config.mjs`. It must come **before**
 
 ```js
 // astro.config.mjs
-import { notro } from "notro/integration";
+import { notro } from "notro-loader/integration";
 import { rehypeMermaid } from "rehype-beautiful-mermaid";
 import rehypeKatex from "rehype-katex";
 import rehypeShiki from "@shikijs/rehype";

--- a/packages/remark-nfm/README.md
+++ b/packages/remark-nfm/README.md
@@ -106,17 +106,17 @@ import { calloutPlugin } from "remark-notro";
 
 A remark transformer that converts `containerDirective` nodes into `<callout>` elements. Included inside `remarkNfm`; direct use is rarely needed.
 
-## Relationship to notro
+## Relationship to notro-loader
 
 ```
 remark-notro        Pure remark plugin — no Astro or Notion API dependencies
    ↑ used by
-notro               Astro + Notion API integration library
+notro-loader        Astro + Notion API integration library
                     (Content Loader / MDX compiler / Astro components)
    ↑ used by
 notro-blog          Deployable Astro template app
 ```
 
 - `remark-notro` has no dependency on Astro or the Notion API and can be published independently
-- `notro` uses `remarkNfm` in its internal MDX compile pipeline
+- `notro-loader` uses `remarkNfm` in its internal MDX compile pipeline
 - You can use `remark-notro` directly in any `unified` or `@mdx-js/mdx` pipeline


### PR DESCRIPTION
## Summary
This PR updates all documentation and code references across the monorepo to reflect the package rename from `notro` to `notro-loader`. This is a documentation and reference update to ensure consistency with the actual package name.

## Key Changes
- Updated all import statements and package references from `notro` to `notro-loader` in README files
- Renamed `remark-nfm` references to `remark-notro` for consistency with the actual package name
- Updated package relationship diagrams and documentation to reflect the correct package names
- Fixed language toggle links in README files (English/Japanese)
- Updated all code examples to import from the correct package names:
  - `notro-loader` for the main content loader and utilities
  - `notro-loader/integration` for Astro integration
  - `remark-notro` for the remark plugin
- Updated cross-references between packages in the monorepo documentation

## Notable Details
- The changes ensure developers will use the correct package names when following the documentation
- All code examples now accurately reflect the actual npm package names
- Documentation in `notro-ui`, `remark-nfm` (now `remark-notro`), and `rehype-beautiful-mermaid` packages have been updated to reference the correct dependencies
- Language toggle links in root README files were corrected to point to the appropriate language versions

https://claude.ai/code/session_011PhDkUi4mdGgT3d3ANdmXP