### PR TITLE
fix: add repository field to notro-ui and restrict release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   push:
     branches: [main]
+    paths:
+      - '.changeset/**'
+      - 'packages/*/package.json'
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/packages/notro-ui/package.json
+++ b/packages/notro-ui/package.json
@@ -5,6 +5,15 @@
   "type": "module",
   "author": "mosugi <mosugeek@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mosugi/notro.git",
+    "directory": "packages/notro-ui"
+  },
+  "homepage": "https://github.com/mosugi/notro",
+  "bugs": {
+    "url": "https://github.com/mosugi/notro/issues"
+  },
   "bin": {
     "notro-ui": "./bin/notro-ui.js"
   },


### PR DESCRIPTION
- Add repository.url to notro-ui/package.json to fix npm provenance validation
  (E422: repository.url was empty, must match https://github.com/mosugi/notro)
- Add paths filter to release.yml so it only triggers on changeset or
  package.json changes, not on every push to main

https://claude.ai/code/session_01FwyzjvpqiHHgiQvg2fmUTg