### PR TITLE
fix: add prepare script to notro-md-sync to build dist on install

### DIFF
--- a/packages/notro-md-sync/package.json
+++ b/packages/notro-md-sync/package.json
@@ -17,6 +17,7 @@
     "dist"
   ],
   "scripts": {
+    "prepare": "tsdown src/index.ts --format esm --out-dir dist",
     "build": "tsdown src/index.ts --format esm --out-dir dist",
     "dev": "tsdown src/index.ts --format esm --out-dir dist --watch"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       typescript:
         specifier: ^5.9.3

--- a/templates/docs/package.json
+++ b/templates/docs/package.json
@@ -12,7 +12,8 @@
     "@astrojs/starlight": "^0.38.2",
     "astro": "^6.0.4",
     "notro-loader": "workspace:*",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"


### PR DESCRIPTION
pnpm failed to create the bin symlink for notro-md-sync during
install because dist/index.js did not exist. Adding a prepare
script ensures tsdown compiles the source before pnpm links the bin.