### PR TITLE
fix(notro-loader): check all presigned URLs in markdown, not just the first

### DIFF
--- a/packages/notro-loader/src/loader/loader.ts
+++ b/packages/notro-loader/src/loader/loader.ts
@@ -61,12 +61,14 @@ function hasExpiredNotionPresignedUrl(data: PageWithMarkdownType): boolean {
     : false;
 }
 
-// Extract the first presigned S3 URL from markdown and check if it has expired.
-// If the markdown contains presigned URLs but none can be parsed, treat as expired.
+// Extract all presigned S3 URLs from markdown and check if any have expired.
+// Returns true if at least one URL is expired; false if all are still valid.
 function isPresignedUrlExpiredInMarkdown(markdown: string): boolean {
-  const match = markdown.match(/https?:\/\/[^\s)"']*[?&]X-Amz-[^\s)"']*/);
-  if (!match) return false;
-  return isPresignedUrlExpired(match[0]);
+  const matches = markdown.matchAll(/https?:\/\/[^\s)"']*[?&]X-Amz-[^\s)"']*/g);
+  for (const [url] of matches) {
+    if (isPresignedUrlExpired(url)) return true;
+  }
+  return false;
 }
 
 // Error codes that are safe to retry (rate limit, server errors).


### PR DESCRIPTION
## Summary

- `isPresignedUrlExpiredInMarkdown` previously used `match()` and only checked the first presigned S3 URL found in the markdown
- If the first URL was still valid, any subsequent expired URLs were silently skipped
- Articles with multiple S3-hosted images could serve stale (broken) images after the later URLs expired

## Fix

Switch from `match()` to `matchAll()` so every presigned URL in the markdown is evaluated. The function returns `true` (triggering a re-fetch) as soon as any single URL has expired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)