### PR TITLE
fix(notro-loader): unify S3 presigned URL detection with isNotionPresignedUrl

### DIFF
--- a/.changeset/unify-presigned-url-detection.md
+++ b/.changeset/unify-presigned-url-detection.md
@@ -1,0 +1,10 @@
+---
+"notro-loader": patch
+---
+
+Add `isNotionPresignedUrl()` helper and unify S3 presigned URL detection
+
+- Export `isNotionPresignedUrl(url)` as a single source of truth for detecting Notion S3 presigned URLs (covers `X-Amz-Algorithm` query param and `prod-files-secure.s3` hostname)
+- Use it in `isPresignedUrlExpired`'s fallback path, replacing the previous overly-broad hostname check
+- Fix `isPresignedUrlExpiredInMarkdown` to check **all** presigned URLs in markdown (was only checking the first), so articles with multiple images are correctly invalidated when any URL expires
+- Align URL extraction regex in `isPresignedUrlExpiredInMarkdown` with `markdownHasPresignedUrls` for consistency

--- a/packages/notro-loader/src/loader/loader.ts
+++ b/packages/notro-loader/src/loader/loader.ts
@@ -14,7 +14,7 @@ import {
   type PageWithMarkdownType,
   pageWithMarkdownSchema,
 } from "./schema.ts";
-import { isPresignedUrlExpired, markdownHasPresignedUrls } from "../utils/notion-url.ts";
+import { isNotionPresignedUrl, isPresignedUrlExpired, markdownHasPresignedUrls } from "../utils/notion-url.ts";
 
 type LoaderOptions = {
   queryParameters: QueryDataSourceParameters;
@@ -61,12 +61,20 @@ function hasExpiredNotionPresignedUrl(data: PageWithMarkdownType): boolean {
     : false;
 }
 
-// Extract the first presigned S3 URL from markdown and check if it has expired.
-// If the markdown contains presigned URLs but none can be parsed, treat as expired.
+// Extract all presigned S3 URLs from markdown and check if any have expired.
+// Returns true as soon as any URL is found to be expired.
+// Uses the same URL pattern as markdownHasPresignedUrls for consistency.
 function isPresignedUrlExpiredInMarkdown(markdown: string): boolean {
-  const match = markdown.match(/https?:\/\/[^\s)"']*[?&]X-Amz-[^\s)"']*/);
-  if (!match) return false;
-  return isPresignedUrlExpired(match[0]);
+  const matches = markdown.matchAll(/https?:\/\/[^\s)"']*[?&]X-Amz-Algorithm=[^\s)"']*/g);
+  for (const [url] of matches) {
+    if (isPresignedUrlExpired(url)) return true;
+  }
+  // Also check prod-files-secure.s3 URLs (may not have X-Amz-Algorithm in some cases)
+  const s3Matches = markdown.matchAll(/https?:\/\/prod-files-secure\.s3[^\s)"']*/g);
+  for (const [url] of s3Matches) {
+    if (isNotionPresignedUrl(url) && isPresignedUrlExpired(url)) return true;
+  }
+  return false;
 }
 
 // Error codes that are safe to retry (rate limit, server errors).

--- a/packages/notro-loader/src/utils/notion-url.test.ts
+++ b/packages/notro-loader/src/utils/notion-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isPresignedUrlExpired } from "./notion-url.ts";
+import { isNotionPresignedUrl, isPresignedUrlExpired } from "./notion-url.ts";
 
 // Build a fake S3 presigned URL with the given issued-at time and expiry.
 function makePresignedUrl(issuedAt: Date, expiresSeconds: number): string {
@@ -9,6 +9,24 @@ function makePresignedUrl(issuedAt: Date, expiresSeconds: number): string {
     .replace(/\.\d+Z$/, "Z"); // YYYYMMDDTHHmmssZ
   return `https://prod-files-secure.s3.us-west-2.amazonaws.com/file.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=${date}&X-Amz-Expires=${expiresSeconds}&X-Amz-Signature=abc`;
 }
+
+describe("isNotionPresignedUrl", () => {
+  it("returns true for a URL with X-Amz-Algorithm param", () => {
+    expect(isNotionPresignedUrl("https://example.s3.amazonaws.com/file.png?X-Amz-Algorithm=AWS4-HMAC-SHA256")).toBe(true);
+  });
+
+  it("returns true for prod-files-secure.s3 hostname", () => {
+    expect(isNotionPresignedUrl("https://prod-files-secure.s3.us-west-2.amazonaws.com/file.png")).toBe(true);
+  });
+
+  it("returns false for a plain external URL", () => {
+    expect(isNotionPresignedUrl("https://example.com/image.png")).toBe(false);
+  });
+
+  it("returns false for a non-URL string", () => {
+    expect(isNotionPresignedUrl("not-a-url")).toBe(false);
+  });
+});
 
 describe("isPresignedUrlExpired", () => {
   const NOW = new Date("2024-06-01T12:00:00Z").getTime();

--- a/packages/notro-loader/src/utils/notion-url.ts
+++ b/packages/notro-loader/src/utils/notion-url.ts
@@ -10,6 +10,24 @@
 const AMZN_PRESIGNED_PARAM = 'X-Amz-Algorithm';
 
 /**
+ * Returns true if the given URL is a Notion S3 pre-signed URL.
+ *
+ * Detection covers two known patterns:
+ * - URLs with `X-Amz-Algorithm` query parameter (standard S3 pre-signed form)
+ * - `prod-files-secure.s3` hostname (Notion's secure file host, may omit X-Amz-* in some contexts)
+ */
+export function isNotionPresignedUrl(url: string): boolean {
+	try {
+		const parsed = new URL(url);
+		if (parsed.searchParams.has(AMZN_PRESIGNED_PARAM)) return true;
+		if (parsed.hostname.startsWith('prod-files-secure.s3')) return true;
+	} catch {
+		// Not a valid URL
+	}
+	return false;
+}
+
+/**
  * Returns true if the given Notion pre-signed S3 URL has expired (or is
  * unrecognisable and should be treated as expired).
  *
@@ -39,7 +57,7 @@ export function isPresignedUrlExpired(url: string, bufferMs = 60_000): boolean {
 		// Not a pre-signed URL with the expected parameters – if it looks like
 		// a Notion S3 URL, conservatively treat as expired; otherwise it is
 		// probably a plain external URL that never expires.
-		return parsed.hostname.includes('s3') && parsed.hostname.includes('amazonaws.com');
+		return isNotionPresignedUrl(url);
 	}
 
 	// X-Amz-Date is in compact ISO-8601: YYYYMMDDTHHmmssZ
@@ -60,13 +78,6 @@ export function isPresignedUrlExpired(url: string, bufferMs = 60_000): boolean {
 
 /**
  * Returns true if the text contains Notion pre-signed S3 URLs.
- *
- * Detection strategy:
- * - X-Amz-Algorithm: must appear as a URL query parameter
- *   (i.e. preceded by "?" or "&" within an https:// URL context) to avoid
- *   false positives when the literal string appears in body text or code blocks.
- * - prod-files-secure.s3: matched as a hostname within an https:// URL, which
- *   is an unambiguous indicator of a Notion S3 URL regardless of query params.
  */
 export function markdownHasPresignedUrls(text: string): boolean {
 	// Match X-Amz-Algorithm only when it appears as a URL query parameter


### PR DESCRIPTION
## Problem

S3 presigned URL detection was scattered across multiple functions with slightly different patterns, making it easy for edge cases to slip through:

- `markdownHasPresignedUrls`: checks `X-Amz-Algorithm` param or `prod-files-secure.s3` hostname
- `isPresignedUrlExpired` fallback: checks `s3` + `amazonaws.com` in hostname (too broad)
- `isPresignedUrlExpiredInMarkdown`: extracts URLs with any `X-Amz-` param (inconsistent with above)

Also, `isPresignedUrlExpiredInMarkdown` used `match()` so only the first presigned URL in markdown was checked — subsequent expired URLs were silently missed (closes #147).

## Changes

- Add `isNotionPresignedUrl(url)` — single exported helper covering both detection patterns
- Use it in `isPresignedUrlExpired`'s fallback path (replaces the overly broad hostname check)
- Rewrite `isPresignedUrlExpiredInMarkdown` to use `matchAll()` and align its regex with `markdownHasPresignedUrls`
- Add tests for `isNotionPresignedUrl`

## Closes

- #147 (check all presigned URLs in markdown, not just the first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)