### PR TITLE
feat(notro-loader): route Notion table elements through components prop

### DIFF
--- a/.changeset/table-component-mapping.md
+++ b/.changeset/table-component-mapping.md
@@ -1,0 +1,9 @@
+---
+"notro-loader": minor
+---
+
+Notion table elements now route through the `components` prop.
+
+`rehypeBlockElementsPlugin` now renames `<table>`, `<colgroup>`, `<col>`, `<tr>`, `<td>` to their PascalCase counterparts (`TableBlock`, `TableColgroup`, `TableCol`, `TableRow`, `TableCell`). This lets the `components` prop (e.g. `notroComponents`) fully control how Notion tables are rendered — including wrapper markup, Tailwind classes, and `data-*` attributes — without requiring CSS overrides on raw HTML elements.
+
+`defaultComponents` gains corresponding pass-through entries so headless mode continues to render plain semantic HTML.

--- a/.changeset/table-component-mapping.md
+++ b/.changeset/table-component-mapping.md
@@ -1,9 +1,28 @@
 ---
 "notro-loader": minor
+"notro-ui": minor
+"remark-notro": patch
 ---
 
-Notion table elements now route through the `components` prop.
+All Notion table elements now route through the `components` prop.
 
-`rehypeBlockElementsPlugin` now renames `<table>`, `<colgroup>`, `<col>`, `<tr>`, `<td>` to their PascalCase counterparts (`TableBlock`, `TableColgroup`, `TableCol`, `TableRow`, `TableCell`). This lets the `components` prop (e.g. `notroComponents`) fully control how Notion tables are rendered — including wrapper markup, Tailwind classes, and `data-*` attributes — without requiring CSS overrides on raw HTML elements.
+`rehypeBlockElementsPlugin` now renames all table-related HTML elements from Notion's raw markdown output to PascalCase so that the `components` prop can fully control rendering:
 
-`defaultComponents` gains corresponding pass-through entries so headless mode continues to render plain semantic HTML.
+| Raw HTML element | PascalCase component key |
+|---|---|
+| `<table>` | `TableBlock` |
+| `<thead>` | `TableHead` |
+| `<tbody>` | `TableBody` |
+| `<colgroup>` | `TableColgroup` |
+| `<col>` | `TableCol` |
+| `<tr>` | `TableRow` |
+| `<th>` | `TableHeaderCell` |
+| `<td>` | `TableCell` |
+
+`defaultComponents` gains corresponding pass-through entries (renders plain semantic HTML in headless mode).
+
+Standard HTML elements generated from GFM pipe table syntax continue to use lowercase component keys (`table`, `thead`, `tbody`, `tr`, `th`, `td`) — both sets can coexist in a single `components` map.
+
+**`notro-ui`**: Adds `TableHead.astro`, `TableBody.astro`, and `TableHeaderCell.astro` templates.
+
+**`remark-notro`**: Fix 9 now also converts `[text](url)` markdown links inside raw `<th>` cells to `<a>` tags (previously only `<td>` was handled).

--- a/packages/notro-loader/src/utils/default-components.ts
+++ b/packages/notro-loader/src/utils/default-components.ts
@@ -46,6 +46,16 @@ export const defaultComponents = {
   MentionAgent:           makeHtmlElement("span"),
   MentionDate:            makeHtmlElement("time"),
 
+  // ── Table elements (renamed from lowercase by rehypeBlockElementsPlugin) ───
+  // Notion outputs raw <table header-row="true">...</table> HTML blocks.
+  // rehypeBlockElementsPlugin renames these to PascalCase so the `components`
+  // prop can substitute them. Default: pass-through as plain HTML elements.
+  TableBlock:    makeHtmlElement("table"),
+  TableColgroup: makeHtmlElement("colgroup"),
+  TableCol:      makeHtmlElement("col"),
+  TableRow:      makeHtmlElement("tr"),
+  TableCell:     makeHtmlElement("td"),
+
   // ── Standard HTML element pass-throughs ──────────────────────────────────
   span:   makeHtmlElement("span"),
   p:      makeHtmlElement("p"),

--- a/packages/notro-loader/src/utils/default-components.ts
+++ b/packages/notro-loader/src/utils/default-components.ts
@@ -50,13 +50,20 @@ export const defaultComponents = {
   // Notion outputs raw <table header-row="true">...</table> HTML blocks.
   // rehypeBlockElementsPlugin renames these to PascalCase so the `components`
   // prop can substitute them. Default: pass-through as plain HTML elements.
-  TableBlock:    makeHtmlElement("table"),
-  TableColgroup: makeHtmlElement("colgroup"),
-  TableCol:      makeHtmlElement("col"),
-  TableRow:      makeHtmlElement("tr"),
-  TableCell:     makeHtmlElement("td"),
+  TableBlock:        makeHtmlElement("table"),
+  TableHead:         makeHtmlElement("thead"),
+  TableBody:         makeHtmlElement("tbody"),
+  TableColgroup:     makeHtmlElement("colgroup"),
+  TableCol:          makeHtmlElement("col"),
+  TableRow:          makeHtmlElement("tr"),
+  TableHeaderCell:   makeHtmlElement("th"),
+  TableCell:         makeHtmlElement("td"),
 
   // ── Standard HTML element pass-throughs ──────────────────────────────────
+  // These lowercase keys override HTML elements generated from markdown syntax
+  // (e.g. GFM tables: <thead>, <tbody>, <tr>, <th>, <td>). They are separate
+  // from the PascalCase entries above, which handle Notion raw HTML elements
+  // renamed by rehypeBlockElementsPlugin.
   span:   makeHtmlElement("span"),
   p:      makeHtmlElement("p"),
   ul:     makeHtmlElement("ul"),
@@ -64,7 +71,11 @@ export const defaultComponents = {
   li:     makeHtmlElement("li"),
   pre:    makeHtmlElement("pre"),
   hr:     makeHtmlElement("hr"),
+  thead:  makeHtmlElement("thead"),
+  tbody:  makeHtmlElement("tbody"),
+  tr:     makeHtmlElement("tr"),
   th:     makeHtmlElement("th"),
+  td:     makeHtmlElement("td"),
   a:      makeHtmlElement("a"),
   strong: makeHtmlElement("strong"),
   em:     makeHtmlElement("em"),

--- a/packages/notro-loader/src/utils/mdx-pipeline.ts
+++ b/packages/notro-loader/src/utils/mdx-pipeline.ts
@@ -226,6 +226,13 @@ const NOTION_BLOCK_RENAMES = new Map<string, string>([
 	['details',                 'Details'],
 	['summary',                 'Summary'],
 	['empty-block',             'EmptyBlock'],
+	// Table elements — Notion outputs raw <table header-row="true">...</table> HTML.
+	// Renaming to PascalCase enables the `components` prop to override them.
+	['table',                   'TableBlock'],
+	['colgroup',                'TableColgroup'],
+	['col',                     'TableCol'],
+	['tr',                      'TableRow'],
+	['td',                      'TableCell'],
 ]);
 
 /**

--- a/packages/notro-loader/src/utils/mdx-pipeline.ts
+++ b/packages/notro-loader/src/utils/mdx-pipeline.ts
@@ -229,9 +229,12 @@ const NOTION_BLOCK_RENAMES = new Map<string, string>([
 	// Table elements — Notion outputs raw <table header-row="true">...</table> HTML.
 	// Renaming to PascalCase enables the `components` prop to override them.
 	['table',                   'TableBlock'],
+	['thead',                   'TableHead'],
+	['tbody',                   'TableBody'],
 	['colgroup',                'TableColgroup'],
 	['col',                     'TableCol'],
 	['tr',                      'TableRow'],
+	['th',                      'TableHeaderCell'],
 	['td',                      'TableCell'],
 ]);
 

--- a/packages/notro-ui/bin/notro-ui.js
+++ b/packages/notro-ui/bin/notro-ui.js
@@ -77,7 +77,7 @@ const COMPONENT_MAP = {
   quote:            ['Quote.astro'],
   styledspan:       ['StyledSpan.astro'],
   image:            ['ImageBlock.astro'],
-  table:            ['TableBlock.astro', 'TableColgroup.astro', 'TableCol.astro', 'TableRow.astro', 'TableCell.astro'],
+  table:            ['TableBlock.astro', 'TableHead.astro', 'TableBody.astro', 'TableColgroup.astro', 'TableCol.astro', 'TableRow.astro', 'TableHeaderCell.astro', 'TableCell.astro'],
   coloredparagraph: ['ColoredParagraph.astro'],
   syncedblock:      ['SyncedBlock.astro'],
 };

--- a/packages/notro-ui/src/templates/TableBody.astro
+++ b/packages/notro-ui/src/templates/TableBody.astro
@@ -1,0 +1,11 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+import { tv } from 'tailwind-variants';
+
+export const tableBody = tv({ base: '' });
+
+type Props = HTMLAttributes<'tbody'>;
+
+const { class: className, ...rest } = Astro.props;
+---
+<tbody class={tableBody({ class: className })} data-slot="table-body" {...rest}><slot /></tbody>

--- a/packages/notro-ui/src/templates/TableHead.astro
+++ b/packages/notro-ui/src/templates/TableHead.astro
@@ -1,0 +1,11 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+import { tv } from 'tailwind-variants';
+
+export const tableHead = tv({ base: '' });
+
+type Props = HTMLAttributes<'thead'>;
+
+const { class: className, ...rest } = Astro.props;
+---
+<thead class={tableHead({ class: className })} data-slot="table-head" {...rest}><slot /></thead>

--- a/packages/notro-ui/src/templates/TableHeaderCell.astro
+++ b/packages/notro-ui/src/templates/TableHeaderCell.astro
@@ -1,0 +1,16 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+import { tv, type VariantProps } from 'tailwind-variants';
+import { notroColorVariants } from './colors';
+
+export const tableHeaderCell = tv({
+  base: 'px-3 py-2 text-left text-sm font-semibold',
+  variants: { color: notroColorVariants },
+  defaultVariants: { color: 'default' },
+});
+
+type Props = Omit<HTMLAttributes<'th'>, 'color'> & VariantProps<typeof tableHeaderCell>;
+
+const { color, class: className, ...rest } = Astro.props;
+---
+<th class={tableHeaderCell({ color, class: className })} data-slot="table-header-cell" {...rest}><slot /></th>

--- a/packages/remark-nfm/src/transformer.ts
+++ b/packages/remark-nfm/src/transformer.ts
@@ -53,9 +53,9 @@
  *
  * 9. Markdown links inside raw HTML table cells:
  *    Notion exports table cell rich-text links as markdown link syntax
- *    [text](url) inside raw HTML <td> blocks. remark does not process inline
- *    markdown inside raw HTML, so these appear as literal text. We convert
- *    them to <a href="url">text</a> before the pipeline runs.
+ *    [text](url) inside raw HTML <td> and <th> blocks. remark does not process
+ *    inline markdown inside raw HTML, so these appear as literal text. We
+ *    convert them to <a href="url">text</a> before the pipeline runs.
  *
  * 10. Tab-indented content inside <details> and <column> blocks:
  *    Notion API outputs content inside <details> and <column> elements with a
@@ -370,20 +370,21 @@ export function preprocessNotionMarkdown(markdown: string): string {
   );
   result = result.replace(blockClosingPattern, "$1\n\n$3");
 
-  // Fix 9: Convert markdown link syntax inside raw HTML <td> cells to <a> tags.
-  // Notion exports table cell links as [text](url) inside <td>...</td>, but remark
-  // does not process inline markdown inside raw HTML blocks. Replace them with
-  // proper anchor elements so they render as clickable links.
+  // Fix 9: Convert markdown link syntax inside raw HTML table cells to <a> tags.
+  // Notion exports table cell links as [text](url) inside <td>...</td> and
+  // <th>...</th>, but remark does not process inline markdown inside raw HTML
+  // blocks. Replace them with proper anchor elements so they render as links.
   // The URL pattern handles one level of nested parentheses, e.g.:
   //   https://en.wikipedia.org/wiki/Rust_(programming_language)
   //   https://developer.mozilla.org/docs/Array/find()
-  result = result.replace(/<td>([\s\S]*?)<\/td>/g, (_, content: string) => {
+  const convertLinksInCell = (_: string, tag: string, content: string): string => {
     const linked = content.replace(
       /\[([^\]\n]+)\]\(([^()\n]*(?:\([^()\n]*\)[^()\n]*)*)\)/g,
       '<a href="$2">$1</a>'
     );
-    return `<td>${linked}</td>`;
-  });
+    return `<${tag}>${linked}</${tag}>`;
+  };
+  result = result.replace(/<(td|th)>([\s\S]*?)<\/\1>/g, convertLinksInCell);
 
   // Fix 10: Dedent tab-indented content inside <details>, <columns>, and <column> blocks.
   // Notion API outputs each content line inside <details> and <column> elements

--- a/templates/blog/src/components/notro/TableBody.astro
+++ b/templates/blog/src/components/notro/TableBody.astro
@@ -1,0 +1,11 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+import { tv } from 'tailwind-variants';
+
+export const tableBody = tv({ base: '' });
+
+type Props = HTMLAttributes<'tbody'>;
+
+const { class: className, ...rest } = Astro.props;
+---
+<tbody class={tableBody({ class: className })} data-slot="table-body" {...rest}><slot /></tbody>

--- a/templates/blog/src/components/notro/TableHead.astro
+++ b/templates/blog/src/components/notro/TableHead.astro
@@ -1,0 +1,11 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+import { tv } from 'tailwind-variants';
+
+export const tableHead = tv({ base: '' });
+
+type Props = HTMLAttributes<'thead'>;
+
+const { class: className, ...rest } = Astro.props;
+---
+<thead class={tableHead({ class: className })} data-slot="table-head" {...rest}><slot /></thead>

--- a/templates/blog/src/components/notro/TableHeaderCell.astro
+++ b/templates/blog/src/components/notro/TableHeaderCell.astro
@@ -1,0 +1,16 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+import { tv, type VariantProps } from 'tailwind-variants';
+import { notroColorVariants } from './colors';
+
+export const tableHeaderCell = tv({
+  base: 'px-3 py-2 text-left text-sm font-semibold',
+  variants: { color: notroColorVariants },
+  defaultVariants: { color: 'default' },
+});
+
+type Props = Omit<HTMLAttributes<'th'>, 'color'> & VariantProps<typeof tableHeaderCell>;
+
+const { color, class: className, ...rest } = Astro.props;
+---
+<th class={tableHeaderCell({ color, class: className })} data-slot="table-header-cell" {...rest}><slot /></th>

--- a/templates/blog/src/components/notro/index.ts
+++ b/templates/blog/src/components/notro/index.ts
@@ -38,11 +38,14 @@ import H3              from './H3.astro';
 import H4              from './H4.astro';
 import StyledSpan      from './StyledSpan.astro';
 import ImageBlock      from './ImageBlock.astro';
-import TableBlock      from './TableBlock.astro';
-import TableColgroup   from './TableColgroup.astro';
-import TableCol        from './TableCol.astro';
-import TableRow        from './TableRow.astro';
-import TableCell       from './TableCell.astro';
+import TableBlock       from './TableBlock.astro';
+import TableHead        from './TableHead.astro';
+import TableBody        from './TableBody.astro';
+import TableColgroup    from './TableColgroup.astro';
+import TableCol         from './TableCol.astro';
+import TableRow         from './TableRow.astro';
+import TableHeaderCell  from './TableHeaderCell.astro';
+import TableCell        from './TableCell.astro';
 
 export const notroComponents = {
   // ── Notion block elements (PascalCase) ────────────────────────────────
@@ -70,7 +73,22 @@ export const notroComponents = {
   MentionAgent:         Mention,
   MentionDate:          MentionDate,
 
+  // ── Notion raw HTML table elements (PascalCase — renamed by rehypeBlockElementsPlugin) ──
+  // These keys handle Notion's raw HTML tables (<table header-row="true">...).
+  // rehypeBlockElementsPlugin renames the mdxJsxFlowElement nodes to PascalCase,
+  // so only PascalCase keys are consulted for Notion raw HTML content.
+  TableBlock:       TableBlock,
+  TableHead:        TableHead,
+  TableBody:        TableBody,
+  TableColgroup:    TableColgroup,
+  TableCol:         TableCol,
+  TableRow:         TableRow,
+  TableHeaderCell:  TableHeaderCell,
+  TableCell:        TableCell,
+
   // ── HTML element overrides ─────────────────────────────────────────────
+  // These lowercase keys handle HTML elements generated from markdown syntax
+  // (e.g. GFM pipe tables produce <table>, <thead>, <tbody>, <tr>, <th>, <td>).
   h1: H1,
   h2: H2,
   h3: H3,
@@ -79,13 +97,13 @@ export const notroComponents = {
   span:       StyledSpan,
   img:        ImageBlock,
   table:      TableBlock,
-  colgroup:   TableColgroup,
-  col:        TableCol,
+  thead:      TableHead,
+  tbody:      TableBody,
   tr:         TableRow,
+  th:         TableHeaderCell,
   td:         TableCell,
 
   // ── Standard HTML elements ─────────────────────────────────────────────
-  th:     makeHtmlElement('th',     'px-3 py-2 text-left text-sm font-semibold'),
   p:      ColoredParagraph,
   ul:     makeHtmlElement('ul',     'mb-4 list-disc pl-6 space-y-1'),
   ol:     makeHtmlElement('ol',     'mb-4 list-decimal pl-6 space-y-1'),


### PR DESCRIPTION
Add table/tr/td/colgroup/col to NOTION_BLOCK_RENAMES so rehypeBlockElementsPlugin
renames them to TableBlock/TableRow/TableCell/TableColgroup/TableCol. MDX then
generates a components-map lookup instead of a plain HTML string, enabling full
control via the components prop.

Add corresponding pass-through entries to defaultComponents for headless mode.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>