### PR TITLE
fix: address open issues and high-priority TODO items

### DIFF
--- a/packages/notro-ui/src/templates/ImageBlock.astro
+++ b/packages/notro-ui/src/templates/ImageBlock.astro
@@ -1,8 +1,10 @@
 ---
 /**
  * Notion image block — renders as <figure> with optional caption.
+ * S3 presigned URLs are downloaded and optimized at build time via <Image>.
  */
 import type { HTMLAttributes } from 'astro/types';
+import { Image } from 'astro:assets';
 import { tv } from 'tailwind-variants';
 
 export const imageBlock = tv({
@@ -21,10 +23,17 @@ type Props = HTMLAttributes<'figure'> & {
 
 const { src, alt, caption, class: className, ...rest } = Astro.props;
 const { root, img, caption: captionClass } = imageBlock();
+
+// S3 presigned URLs expire after ~1 hour; download at build time to get a permanent /_astro/ URL
+const isS3Url = src.includes('X-Amz-') || src.includes('prod-files-secure.s3');
 ---
 
 <figure class={root({ class: className })} data-slot="image-block" {...rest}>
-  <img src={src} alt={alt ?? ''} loading="lazy" decoding="async" class={img()} data-slot="image-block-img" />
+  {isS3Url ? (
+    <Image src={src} inferSize alt={alt ?? ''} loading="lazy" class={img()} data-slot="image-block-img" />
+  ) : (
+    <img src={src} alt={alt ?? ''} loading="lazy" decoding="async" class={img()} data-slot="image-block-img" />
+  )}
   {caption && (
     <figcaption class={captionClass()} data-slot="image-block-caption">
       {caption}

--- a/templates/blog/.env.example
+++ b/templates/blog/.env.example
@@ -4,8 +4,8 @@ NOTION_TOKEN=secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Notion Database ID (data source)
 # Found in your database URL: notion.so/<workspace>/<database_id>?...
-NOTION_DATASOURCE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-
-# Google Analytics 4 Measurement ID (optional)
-# Example: G-XXXXXXXXXX
-# PUBLIC_GTAG_ID=G-XXXXXXXXXX
+#
+# NOTION_DATASOURCE_ID_BLOG is the recommended variable for the blog template.
+# NOTION_DATASOURCE_ID is a fallback used when NOTION_DATASOURCE_ID_BLOG is not set.
+NOTION_DATASOURCE_ID_BLOG=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# NOTION_DATASOURCE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/templates/blog/src/components/blog/BlogList.astro
+++ b/templates/blog/src/components/blog/BlogList.astro
@@ -4,9 +4,10 @@ import PostCard from "./PostCard.astro";
 
 interface Props {
   posts: CollectionEntry<"posts">["data"][];
+  slugMap?: Map<string, string>;
 }
 
-const { posts } = Astro.props;
+const { posts, slugMap } = Astro.props;
 ---
 
 {
@@ -14,7 +15,7 @@ const { posts } = Astro.props;
     <ul class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {posts.map((data) => (
         <li>
-          <PostCard data={data} />
+          <PostCard data={data} slugMap={slugMap} />
         </li>
       ))}
     </ul>

--- a/templates/blog/src/components/blog/DatabaseCover.astro
+++ b/templates/blog/src/components/blog/DatabaseCover.astro
@@ -10,17 +10,20 @@ interface Props {
 const { cover, alt, class: className } = Astro.props;
 
 const imageUrl = cover?.type === "file" ? cover?.file.url : cover?.external?.url;
+
+// S3 presigned URLs (Notion file-type covers) expire after ~1 hour.
+// Use inferSize to download and cache the image at build time.
+const isS3Url = imageUrl ? (imageUrl.includes("X-Amz-") || imageUrl.includes("prod-files-secure.s3")) : false;
 ---
 
 {
   imageUrl ? (
     <div class:list={["nt-collection-cover", className]}>
-      <Image
-        src={imageUrl}
-        alt={alt ?? ""}
-        width={1200}
-        height={630}
-      />
+      {isS3Url ? (
+        <Image src={imageUrl} inferSize alt={alt ?? ""} />
+      ) : (
+        <Image src={imageUrl} alt={alt ?? ""} width={1200} height={630} />
+      )}
     </div>
   ) : null
 }

--- a/templates/blog/src/components/blog/PostCard.astro
+++ b/templates/blog/src/components/blog/PostCard.astro
@@ -1,6 +1,6 @@
 ---
 import type { CollectionEntry } from "astro:content";
-import { getPlainText, getMultiSelect } from "notro-loader";
+import { getPlainText, getMultiSelect } from "notro-loader/utils";
 import DatabaseCover from "./DatabaseCover.astro";
 import config from "../../config";
 

--- a/templates/blog/src/components/blog/PostCard.astro
+++ b/templates/blog/src/components/blog/PostCard.astro
@@ -6,11 +6,12 @@ import config from "../../config";
 
 interface Props {
   data: CollectionEntry<"posts">["data"];
+  slugMap?: Map<string, string>;
 }
 
-const { data } = Astro.props;
+const { data, slugMap } = Astro.props;
 
-const slug = getPlainText(data.properties.Slug) || data.id;
+const slug = slugMap?.get(data.id) ?? (getPlainText(data.properties.Slug) || data.id);
 const title = getPlainText(data.properties.Name);
 const description = getPlainText(data.properties.Description);
 const date = data.properties.Date?.type === "date" ? data.properties.Date.date?.start : undefined;

--- a/templates/blog/src/components/notro/ImageBlock.astro
+++ b/templates/blog/src/components/notro/ImageBlock.astro
@@ -1,8 +1,10 @@
 ---
 /**
  * Notion image block — renders as <figure> with optional caption.
+ * S3 presigned URLs are downloaded and optimized at build time via <Image>.
  */
 import type { HTMLAttributes } from 'astro/types';
+import { Image } from 'astro:assets';
 import { tv } from 'tailwind-variants';
 
 export const imageBlock = tv({
@@ -21,10 +23,17 @@ type Props = HTMLAttributes<'figure'> & {
 
 const { src, alt, caption, class: className, ...rest } = Astro.props;
 const { root, img, caption: captionClass } = imageBlock();
+
+// S3 presigned URLs expire after ~1 hour; download at build time to get a permanent /_astro/ URL
+const isS3Url = src.includes('X-Amz-') || src.includes('prod-files-secure.s3');
 ---
 
 <figure class={root({ class: className })} data-slot="image-block" {...rest}>
-  <img src={src} alt={alt ?? ''} loading="lazy" decoding="async" class={img()} data-slot="image-block-img" />
+  {isS3Url ? (
+    <Image src={src} inferSize alt={alt ?? ''} loading="lazy" class={img()} data-slot="image-block-img" />
+  ) : (
+    <img src={src} alt={alt ?? ''} loading="lazy" decoding="async" class={img()} data-slot="image-block-img" />
+  )}
   {caption && (
     <figcaption class={captionClass()} data-slot="image-block-caption">
       {caption}

--- a/templates/blog/src/config.ts
+++ b/templates/blog/src/config.ts
@@ -22,6 +22,8 @@ const config = {
   },
   blog: {
     postsPerPage: 10,
+    // Shown as <meta description> on the blog list page
+    description: "",
     // System tags — affect post filtering logic (not shown as public tags)
     // "page"   — marks a Notion post as a fixed page (excluded from blog listing)
     // "pinned" — marks a post to appear at the top of the blog list (page 1 only)

--- a/templates/blog/src/env.d.ts
+++ b/templates/blog/src/env.d.ts
@@ -5,8 +5,6 @@ interface ImportMetaEnv {
   // Notion API credentials (required)
   readonly NOTION_TOKEN: string;
   readonly NOTION_DATASOURCE_ID: string;
-  // Google Analytics (optional — omit to disable gtag)
-  readonly PUBLIC_GTAG_ID?: string;
 }
 
 interface ImportMeta {

--- a/templates/blog/src/layouts/Layout.astro
+++ b/templates/blog/src/layouts/Layout.astro
@@ -25,7 +25,6 @@ interface Props {
 
 const { title, description, bodyClass, type = "website", ogImageAlt, datePublished, prevUrl, nextUrl, noindex } = Astro.props;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin).toString();
-const gtagId = import.meta.env.PUBLIC_GTAG_ID;
 ---
 
 <!doctype html>
@@ -42,12 +41,6 @@ const gtagId = import.meta.env.PUBLIC_GTAG_ID;
       nextUrl={nextUrl}
       noindex={noindex}
     />
-    {gtagId && (
-      <>
-        <script is:inline async type="text/partytown" src={`https://www.googletagmanager.com/gtag/js?id=${gtagId}`}></script>
-        <script is:inline type="text/partytown" set:html={`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${gtagId}');`}></script>
-      </>
-    )}
   </head>
   <body class={bodyClass}>
     <Header />

--- a/templates/blog/src/lib/blog.test.ts
+++ b/templates/blog/src/lib/blog.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   getSortedBlogPosts,
+  buildSlugMap,
   toNavEntry,
   getAdjacentPosts,
   getPublicTags,
@@ -71,6 +72,53 @@ describe("getSortedBlogPosts", () => {
 });
 
 // ─────────────────────────────────────────────
+// buildSlugMap
+// ─────────────────────────────────────────────
+describe("buildSlugMap", () => {
+  it("assigns each entry its raw slug when no duplicates", () => {
+    const posts = [
+      makeEntry({ id: "a", slug: "alpha" }),
+      makeEntry({ id: "b", slug: "beta" }),
+    ];
+    const map = buildSlugMap(posts);
+    expect(map.get("a")).toBe("alpha");
+    expect(map.get("b")).toBe("beta");
+  });
+
+  it("falls back to entry.id when Slug is empty", () => {
+    const posts = [makeEntry({ id: "no-slug" })];
+    const map = buildSlugMap(posts);
+    expect(map.get("no-slug")).toBe("no-slug");
+  });
+
+  it("appends -2, -3 for duplicate slugs in order", () => {
+    const posts = [
+      makeEntry({ id: "first", slug: "same" }),
+      makeEntry({ id: "second", slug: "same" }),
+      makeEntry({ id: "third", slug: "same" }),
+    ];
+    const map = buildSlugMap(posts);
+    expect(map.get("first")).toBe("same");
+    expect(map.get("second")).toBe("same-2");
+    expect(map.get("third")).toBe("same-3");
+  });
+
+  it("deduplicates independently for each unique base slug", () => {
+    const posts = [
+      makeEntry({ id: "a1", slug: "a" }),
+      makeEntry({ id: "b1", slug: "b" }),
+      makeEntry({ id: "a2", slug: "a" }),
+      makeEntry({ id: "b2", slug: "b" }),
+    ];
+    const map = buildSlugMap(posts);
+    expect(map.get("a1")).toBe("a");
+    expect(map.get("b1")).toBe("b");
+    expect(map.get("a2")).toBe("a-2");
+    expect(map.get("b2")).toBe("b-2");
+  });
+});
+
+// ─────────────────────────────────────────────
 // toNavEntry
 // ─────────────────────────────────────────────
 describe("toNavEntry", () => {
@@ -87,6 +135,12 @@ describe("toNavEntry", () => {
   it("falls back to entry.id when Name is empty", () => {
     const entry = makeEntry({ id: "id-only", slug: "s" });
     expect(toNavEntry(entry)).toEqual({ slug: "s", title: "id-only" });
+  });
+
+  it("uses slugMap value when provided", () => {
+    const entry = makeEntry({ id: "p1", slug: "original", name: "Post" });
+    const slugMap = new Map([["p1", "original-2"]]);
+    expect(toNavEntry(entry, slugMap)).toEqual({ slug: "original-2", title: "Post" });
   });
 });
 
@@ -122,6 +176,16 @@ describe("getAdjacentPosts", () => {
     const { prevNav, nextNav } = getAdjacentPosts(posts, "nonexistent");
     expect(prevNav).toBeUndefined();
     expect(nextNav).toBeUndefined();
+  });
+
+  it("uses slugMap values for adjacent post slugs", () => {
+    const slugMap = new Map([
+      ["newest", "newest-2"],
+      ["middle", "middle"],
+      ["oldest", "oldest"],
+    ]);
+    const { prevNav } = getAdjacentPosts(posts, "middle", slugMap);
+    expect(prevNav?.slug).toBe("newest-2");
   });
 });
 

--- a/templates/blog/src/lib/blog.ts
+++ b/templates/blog/src/lib/blog.ts
@@ -16,10 +16,42 @@ export function getSortedBlogPosts(posts: PostEntry[]): PostEntry[] {
     });
 }
 
+/**
+ * Builds a map from post entry ID to deduplicated slug.
+ * When multiple posts share the same Slug value, later posts (by array order)
+ * receive a numeric suffix (-2, -3, ...). Logs a warning for each duplicate found.
+ */
+export function buildSlugMap(posts: PostEntry[]): Map<string, string> {
+  const slugCounts = new Map<string, number>();
+  const result = new Map<string, string>();
+
+  for (const entry of posts) {
+    const rawSlug = getPlainText(entry.data.properties.Slug) || entry.id;
+    const count = slugCounts.get(rawSlug) ?? 0;
+    slugCounts.set(rawSlug, count + 1);
+
+    if (count > 0) {
+      const deduped = `${rawSlug}-${count + 1}`;
+      console.warn(
+        `[notro] Duplicate slug "${rawSlug}" (page ${entry.id}). ` +
+          `Using "${deduped}". Set a unique Slug in Notion to fix this.`,
+      );
+      result.set(entry.id, deduped);
+    } else {
+      result.set(entry.id, rawSlug);
+    }
+  }
+
+  return result;
+}
+
 /** Converts a post entry to a minimal nav object { slug, title }. */
-export function toNavEntry(entry: PostEntry): { slug: string; title: string } {
+export function toNavEntry(
+  entry: PostEntry,
+  slugMap?: Map<string, string>,
+): { slug: string; title: string } {
   return {
-    slug: getPlainText(entry.data.properties.Slug) || entry.id,
+    slug: slugMap?.get(entry.id) ?? (getPlainText(entry.data.properties.Slug) || entry.id),
     title: getPlainText(entry.data.properties.Name) ?? entry.id,
   };
 }
@@ -31,16 +63,17 @@ export function toNavEntry(entry: PostEntry): { slug: string; title: string } {
 export function getAdjacentPosts(
   sortedPosts: PostEntry[],
   currentId: string,
+  slugMap?: Map<string, string>,
 ): {
   prevNav: { slug: string; title: string } | undefined;
   nextNav: { slug: string; title: string } | undefined;
 } {
   const idx = sortedPosts.findIndex((p) => p.id === currentId);
   return {
-    prevNav: idx > 0 ? toNavEntry(sortedPosts[idx - 1]!) : undefined,
+    prevNav: idx > 0 ? toNavEntry(sortedPosts[idx - 1]!, slugMap) : undefined,
     nextNav:
       idx >= 0 && idx < sortedPosts.length - 1
-        ? toNavEntry(sortedPosts[idx + 1]!)
+        ? toNavEntry(sortedPosts[idx + 1]!, slugMap)
         : undefined,
   };
 }

--- a/templates/blog/src/pages/404.astro
+++ b/templates/blog/src/pages/404.astro
@@ -1,8 +1,9 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import config from "../config";
 ---
 
-<Layout title="ページが見つかりません — Notro Tail" description="お探しのページは存在しないか、移動した可能性があります。">
+<Layout title={`ページが見つかりません — ${config.site.name}`} description="お探しのページは存在しないか、移動した可能性があります。">
   <main id="main-content" class="max-w-2xl mx-auto px-4 py-20 text-center">
     <p class="text-6xl font-bold text-gray-200 mb-4">404</p>
     <h1 class="text-2xl font-semibold text-gray-900 mb-4">ページが見つかりません</h1>

--- a/templates/blog/src/pages/blog/[...page].astro
+++ b/templates/blog/src/pages/blog/[...page].astro
@@ -6,7 +6,7 @@ import BlogList from "../../components/blog/BlogList.astro";
 import Layout from "../../layouts/Layout.astro";
 import Pagination from "../../components/blog/Pagination.astro";
 import config from "../../config";
-import { getSortedBlogPosts, getPinnedPosts, getBeginnerPosts } from "../../lib/blog.ts";
+import { getSortedBlogPosts, getPinnedPosts, getBeginnerPosts, buildSlugMap } from "../../lib/blog.ts";
 
 export async function getStaticPaths({
   paginate,
@@ -31,6 +31,10 @@ export async function getStaticPaths({
 
 const { page, pinnedPostsData, beginnerPostsData } = Astro.props;
 
+// Build slug map from all posts to handle duplicate slugs (getCollection is cached by Astro)
+const allPostsForSlug = await getCollection("posts");
+const slugMap = buildSlugMap(allPostsForSlug);
+
 // Exclude pinned and beginner posts from the regular list to avoid duplication with each section
 const data = page.data
   .filter((entry) => !hasTag(entry.data.properties.Tags, "pinned"))
@@ -46,7 +50,7 @@ const data = page.data
     {page.currentPage === 1 && pinnedPostsData.length > 0 && (
       <section class="mb-10">
         <h2 class="mb-4 text-lg font-semibold text-gray-700 dark:text-gray-300">ピン留め</h2>
-        <BlogList posts={pinnedPostsData} />
+        <BlogList posts={pinnedPostsData} slugMap={slugMap} />
       </section>
     )}
     {page.currentPage > 1 && pinnedPostsData.length > 0 && (
@@ -57,7 +61,7 @@ const data = page.data
     {page.currentPage === 1 && beginnerPostsData.length > 0 && (
       <section class="mb-10">
         <h2 class="mb-4 text-lg font-semibold text-gray-700 dark:text-gray-300">入門</h2>
-        <BlogList posts={beginnerPostsData} />
+        <BlogList posts={beginnerPostsData} slugMap={slugMap} />
       </section>
     )}
     {page.currentPage > 1 && beginnerPostsData.length > 0 && (
@@ -65,7 +69,7 @@ const data = page.data
         <a href="/blog/" class="text-sky-600 hover:underline dark:text-sky-400">← 入門記事</a>は1ページ目にあります
       </p>
     )}
-    <BlogList posts={data} />
+    <BlogList posts={data} slugMap={slugMap} />
     <Pagination
       currentPage={page.currentPage}
       lastPage={page.lastPage}

--- a/templates/blog/src/pages/blog/[...page].astro
+++ b/templates/blog/src/pages/blog/[...page].astro
@@ -1,7 +1,7 @@
 ---
 import type { PaginateFunction } from "astro";
 import { getCollection } from "astro:content";
-import { hasTag } from "notro-loader";
+import { hasTag } from "notro-loader/utils";
 import BlogList from "../../components/blog/BlogList.astro";
 import Layout from "../../layouts/Layout.astro";
 import Pagination from "../../components/blog/Pagination.astro";
@@ -38,7 +38,7 @@ const data = page.data
   .map(({ data }) => data);
 ---
 
-<Layout title={`ブログ — ${config.site.name}`} description="Notion × Astro で作られたブログ。セットアップ・カスタマイズ・デプロイまで、notro の使い方を解説します。" prevUrl={page.url.prev} nextUrl={page.url.next}>
+<Layout title={`ブログ — ${config.site.name}`} description={config.blog.description || config.site.description} prevUrl={page.url.prev} nextUrl={page.url.next}>
   <main id="main-content" class="mx-auto max-w-screen-xl px-4 py-8 sm:px-6 lg:px-8">
     <div class="mb-8">
       <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Blog</h1>

--- a/templates/blog/src/pages/blog/[slug].astro
+++ b/templates/blog/src/pages/blog/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
-import { buildLinkToPages, getPlainText, hasTag, NotroContent } from "notro-loader";
+import { NotroContent } from "notro-loader";
+import { buildLinkToPages, getPlainText, hasTag } from "notro-loader/utils";
 import Layout from "../../layouts/Layout.astro";
 import { notroComponents } from "../../components/notro";
 import config from "../../config";
@@ -8,22 +9,24 @@ import {
   getSortedBlogPosts,
   getAdjacentPosts,
   getPublicTags,
+  buildSlugMap,
 } from "../../lib/blog.ts";
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts");
+  const slugMap = buildSlugMap(posts);
 
   // Build linkToPages map so NotroContent can resolve inter-page links
   const linkToPages = buildLinkToPages(posts, {
-    url: (e) => `blog/${getPlainText(e.data.properties.Slug) || e.id}/`,
+    url: (e) => `blog/${slugMap.get(e.id) ?? (getPlainText(e.data.properties.Slug) || e.id)}/`,
     title: (e) => getPlainText(e.data.properties.Name) ?? e.id,
   });
 
   const blogPosts = getSortedBlogPosts(posts);
 
   return posts.map((entry) => {
-    const slug = getPlainText(entry.data.properties.Slug) || entry.id;
-    const { prevNav, nextNav } = getAdjacentPosts(blogPosts, entry.id);
+    const slug = slugMap.get(entry.id)!;
+    const { prevNav, nextNav } = getAdjacentPosts(blogPosts, entry.id, slugMap);
     return {
       params: { slug },
       props: { entry, linkToPages, prevNav, nextNav },

--- a/templates/blog/src/pages/blog/tag/[tag]/[...page].astro
+++ b/templates/blog/src/pages/blog/tag/[tag]/[...page].astro
@@ -1,7 +1,7 @@
 ---
 import type { PaginateFunction } from "astro";
 import { getCollection } from "astro:content";
-import { hasTag } from "notro-loader";
+import { hasTag } from "notro-loader/utils";
 import BlogList from "../../../../components/blog/BlogList.astro";
 import Layout from "../../../../layouts/Layout.astro";
 import Pagination from "../../../../components/blog/Pagination.astro";

--- a/templates/blog/src/pages/blog/tag/[tag]/[...page].astro
+++ b/templates/blog/src/pages/blog/tag/[tag]/[...page].astro
@@ -6,7 +6,7 @@ import BlogList from "../../../../components/blog/BlogList.astro";
 import Layout from "../../../../layouts/Layout.astro";
 import Pagination from "../../../../components/blog/Pagination.astro";
 import config from "../../../../config";
-import { getAllPublicTags } from "../../../../lib/blog.ts";
+import { getAllPublicTags, buildSlugMap } from "../../../../lib/blog.ts";
 
 export async function getStaticPaths({
   paginate,
@@ -30,6 +30,10 @@ export async function getStaticPaths({
 const { page } = Astro.props;
 const { tag } = Astro.params;
 
+// Build slug map from all posts to handle duplicate slugs (getCollection is cached by Astro)
+const allPostsForSlug = await getCollection("posts");
+const slugMap = buildSlugMap(allPostsForSlug);
+
 const data = page.data.map(({ data }) => data);
 ---
 
@@ -41,7 +45,7 @@ const data = page.data.map(({ data }) => data);
       </a>
       <h1 class="text-3xl font-bold text-gray-900">タグ: {tag}</h1>
     </div>
-    <BlogList posts={data} />
+    <BlogList posts={data} slugMap={slugMap} />
     <Pagination
       currentPage={page.currentPage}
       lastPage={page.lastPage}

--- a/templates/blog/src/pages/index.astro
+++ b/templates/blog/src/pages/index.astro
@@ -3,9 +3,10 @@ import { getCollection } from "astro:content";
 import Layout from "../layouts/Layout.astro";
 import config from "../config";
 import BlogList from "../components/blog/BlogList.astro";
-import { getSortedBlogPosts, getPinnedPosts } from "../lib/blog";
+import { getSortedBlogPosts, getPinnedPosts, buildSlugMap } from "../lib/blog";
 
 const allPosts = await getCollection("posts");
+const slugMap = buildSlugMap(allPosts);
 const blogPosts = getSortedBlogPosts(allPosts);
 const pinnedPosts = getPinnedPosts(blogPosts);
 const recentPosts = blogPosts
@@ -20,12 +21,12 @@ const pinnedPostsData = pinnedPosts.map(({ data }) => data);
     {pinnedPostsData.length > 0 && (
       <section class="mb-12">
         <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-6">ピン留め</h2>
-        <BlogList posts={pinnedPostsData} />
+        <BlogList posts={pinnedPostsData} slugMap={slugMap} />
       </section>
     )}
     <section>
       <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-6">最新記事</h2>
-      <BlogList posts={recentPosts} />
+      <BlogList posts={recentPosts} slugMap={slugMap} />
       <div class="mt-8 text-center">
         <a href="/blog/" class="text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition-colors">
           すべての記事を見る →

--- a/templates/blog/src/pages/rss.xml.ts
+++ b/templates/blog/src/pages/rss.xml.ts
@@ -1,7 +1,7 @@
 import rss from "@astrojs/rss";
 import type { APIContext } from "astro";
 import { getCollection } from "astro:content";
-import { getPlainText, hasTag } from "notro-loader";
+import { getPlainText, hasTag } from "notro-loader/utils";
 import config from "../config";
 
 export async function GET(context: APIContext) {

--- a/templates/blog/src/pages/rss.xml.ts
+++ b/templates/blog/src/pages/rss.xml.ts
@@ -3,9 +3,11 @@ import type { APIContext } from "astro";
 import { getCollection } from "astro:content";
 import { getPlainText, hasTag } from "notro-loader/utils";
 import config from "../config";
+import { buildSlugMap } from "../lib/blog";
 
 export async function GET(context: APIContext) {
   const posts = await getCollection("posts");
+  const slugMap = buildSlugMap(posts);
 
   // Exclude fixed pages; sort by date descending
   const blogPosts = posts
@@ -21,7 +23,7 @@ export async function GET(context: APIContext) {
     description: config.site.description,
     site: context.site ?? context.url.origin,
     items: blogPosts.map((entry) => {
-      const slug = getPlainText(entry.data.properties.Slug) || entry.id;
+      const slug = slugMap.get(entry.id) ?? (getPlainText(entry.data.properties.Slug) || entry.id);
       const title = getPlainText(entry.data.properties.Name) ?? entry.id;
       const description = getPlainText(entry.data.properties.Description);
       const pubDate = entry.data.properties.Date.date?.start


### PR DESCRIPTION
Closes #146, #46. Refs #10 (closed separately).

- fix(#146): ImageBlock uses <Image inferSize> for S3 presigned URLs to
  download and optimize images at build time, preventing broken links
  after ~1 hour expiry (packages/notro-ui and templates/blog)

- feat(#46): add buildSlugMap() to deduplicate Notion Slug property
  values; duplicate slugs now get -2, -3 suffixes with a console warning.
  getAdjacentPosts/toNavEntry accept optional slugMap for consistent nav links.

- fix(M1): switch 5 files from "notro-loader" to "notro-loader/utils" for
  pure TS utilities (getPlainText, hasTag, getMultiSelect, buildLinkToPages)

- fix(U2): remove redundant PUBLIC_GTAG_ID GA block from Layout.astro;
  keep only config.analytics.gaMeasurementId in SeoHead.astro

- fix(U1): use config.site.name in 404.astro title instead of hardcoded
  "Notro Tail"; move blog list description to config.blog.description

- fix(U8): update .env.example to document NOTION_DATASOURCE_ID_BLOG
  (recommended) vs NOTION_DATASOURCE_ID (fallback) with comments

https://claude.ai/code/session_01Jt3JhbEA5e61ZrVzvnxPGX