### PR TITLE
chore: add changeset for create-notro minor bump

### DIFF
--- a/.changeset/add-basics-template.md
+++ b/.changeset/add-basics-template.md
@@ -1,0 +1,5 @@
+---
+"create-notro": minor
+---
+
+Add basics template as the recommended starter option in the CLI, with 5 total template choices (basics, blog, docs, gallery, blank).


### PR DESCRIPTION
Adds a minor changeset for `create-notro` to record the addition of the basics template and 5-option CLI selection added in #168.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sUofuDECQh351ZiK5VYhy)_